### PR TITLE
Implement single image rendering

### DIFF
--- a/ExplorerGL.cpp
+++ b/ExplorerGL.cpp
@@ -7,25 +7,167 @@ EVT_LEFT_UP(ExplorerGL::leftClick)
 wxEND_EVENT_TABLE()
 
 wxDEFINE_EVENT(EVT_RENDER, wxCommandEvent);
+wxDEFINE_EVENT(EVT_FRAGMENT, wxCommandEvent);
 
 ExplorerGL::ExplorerGL(wxWindow* parent, int id, int* args)
     : PreviewGL(parent, id, args)
 {
-    
+
+    // test which the name of the last image
+    struct stat buffer;
+    std::string nameToTest;
+    for (int i = 0; i < 10000; i++)
+    {
+        nameToTest = "images/" + std::to_string(i) + ".png";
+        if (FILE* file = fopen(nameToTest.c_str(), "r")) {
+            fclose(file);
+        }
+        else {
+            nbGeneratedImgs = i;
+            break;
+        }
+    }
 }
 
 void ExplorerGL::render(wxPaintEvent& evt)
 {
+    glFinish();
+    clock_t begin = clock();
+
     PreviewGL::render(evt);
 
+    glFinish();
+    clock_t end = clock();
+
+    fpsAvg = genTimeSMA(CLOCKS_PER_SEC / double(end - begin));
     wxCommandEvent event(EVT_RENDER, GetId());
     ProcessWindowEvent(event);
+}
+
+void ExplorerGL::renderFull(int renderIters, int renderWidth, int renderHeight, int renderQuality)
+{
+    glUniform2f(windowSizeLocation, renderWidth, renderHeight);
+    glUniform1i(iterationsLocation, renderIters);
+    glUniform1i(qualityLocation, renderQuality);
+
+    GLuint frameBuffer;
+    glGenFramebuffers(1, &frameBuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
+
+    GLuint t;
+    glGenTextures(1, &t);
+    glBindTexture(GL_TEXTURE_2D, t);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, renderWidth, renderHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, t, 0);
+
+    glClearColor(1.0, 0.0, 1.0, 1.0);
+    glClear(GL_COLOR_BUFFER_BIT);
+    prepare2DViewport(0, 0, renderWidth, renderHeight);
+    glLoadIdentity();
+    glColor4f(1, 1, 1, 1);
+    glBegin(GL_QUADS);
+    glVertex2f(-renderWidth, -renderHeight);
+    glVertex2f(renderWidth, -renderHeight);
+    glVertex2f(renderWidth, renderHeight);
+    glVertex2f(-renderWidth, renderHeight);
+    glEnd();
+    glFlush();
+
+    cv::Mat image(renderHeight, renderWidth, CV_8UC3);
+    glReadPixels(0, 0, renderWidth, renderHeight, GL_BGR, GL_UNSIGNED_BYTE, image.data); // somehow this line only wants multiples of 20 as width, I HAVE NO FUCKING IDEA WHY
+
+    cv::imwrite("images/" + std::to_string(nbGeneratedImgs) + ".png", image);
+    nbGeneratedImgs++;
+
+    glDeleteFramebuffers(1, &frameBuffer);
+    glDeleteTextures(1, &t);
+
+    glUniform2f(windowSizeLocation, getWidth(), getHeight());
+    glUniform1i(iterationsLocation, iterations);
+    glUniform1i(qualityLocation, quality);
+}
+
+void ExplorerGL::renderFullFragmented(int renderIters, int renderWidth, int renderHeight, int renderQuality, int nbFrags)
+{
+    int fragmentHeight = renderHeight / nbFrags;
+    int fragmentWidth = renderWidth;
+
+    glUniform2f(windowSizeLocation, fragmentWidth, fragmentHeight);
+    glUniform1d(zoomLocation, zoom * nbFrags);
+    glUniform1i(iterationsLocation, renderIters);
+    glUniform1i(qualityLocation, renderQuality);
+
+    GLuint frameBuffer;
+    glGenFramebuffers(1, &frameBuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
+
+    GLuint t;
+    glGenTextures(1, &t);
+    glBindTexture(GL_TEXTURE_2D, t);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, fragmentWidth, fragmentHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, t, 0);
+
+    glClearColor(1.0, 0.0, 1.0, 1.0);
+    glClear(GL_COLOR_BUFFER_BIT);
+    prepare2DViewport(0, 0, fragmentWidth, fragmentHeight);
+    glLoadIdentity();
+    
+
+    cv::Mat image(renderHeight, renderWidth, CV_8UC3);
+    cv::Mat fragment(fragmentHeight, fragmentWidth, CV_8UC3);
+    double dstY = 1 / zoom;
+    double centerFragY;
+
+    for (int i = 0; i < nbFrags; i++)
+    {
+        centerFragY = centerY - dstY / 2 + dstY / (nbFrags * 2) + i * dstY / nbFrags;
+        glUniform2d(centerPosLocation, centerX, centerFragY);
+        glBegin(GL_QUADS);
+        glVertex2f(-fragmentWidth, -fragmentHeight);
+        glVertex2f(fragmentWidth, -fragmentHeight);
+        glVertex2f(fragmentWidth, fragmentHeight);
+        glVertex2f(-fragmentWidth, fragmentHeight);
+        glEnd();
+        glFlush();
+        glReadBuffer(GL_COLOR_ATTACHMENT0);
+        glReadPixels(0, 0, fragmentWidth, fragmentHeight, GL_BGR, GL_UNSIGNED_BYTE, fragment.data); // somehow this line only wants multiples of 20 as width, I HAVE NO FUCKING IDEA WHY
+        fragment.copyTo(image(cv::Rect(0, i * fragmentHeight, fragmentWidth, fragmentHeight)));
+        wxSafeYield();
+        wxCommandEvent event(EVT_FRAGMENT, GetId());
+        event.SetInt(i + 1);
+        ProcessWindowEvent(event);
+    }
+
+    cv::imwrite("images/" + std::to_string(nbGeneratedImgs) + ".png", image);
+    nbGeneratedImgs++;
+
+    glDeleteFramebuffers(1, &frameBuffer);
+    glDeleteTextures(1, &t);
+
+    glUniform2f(windowSizeLocation, getWidth(), getHeight());
+    glUniform1d(zoomLocation, zoom);
+    glUniform1i(iterationsLocation, iterations);
+    glUniform1i(qualityLocation, quality);
+    glUniform2d(centerPosLocation, centerX, centerY);
 }
 
 double ExplorerGL::getZoomSensivity()
 {
     return zoomSensivity;
 }
+int ExplorerGL::getFPS()
+{
+    return fpsAvg;
+}
+
 void ExplorerGL::setZoomSensivity(double zoomSensivityArg)
 {
     zoomSensivity = zoomSensivityArg;

--- a/ExplorerGL.h
+++ b/ExplorerGL.h
@@ -1,19 +1,31 @@
 #pragma once
 #include "PreviewGL.h"
+#include "SMA.h"
+#include <ctime>
+#define FPS_ROLLING_AVG_NB_ELEMS 10
 
 wxDECLARE_EVENT(EVT_RENDER, wxCommandEvent);
+wxDECLARE_EVENT(EVT_FRAGMENT, wxCommandEvent);
 
 class ExplorerGL :
     public PreviewGL
 {
+public:
     double zoomSensivity = 1.2;
+    SMA<FPS_ROLLING_AVG_NB_ELEMS, unsigned int, unsigned int> genTimeSMA;
+    int fpsAvg;
+    int nbGeneratedImgs = 0;
 
 public:
     ExplorerGL(wxWindow* parent, int id, int* args);
 
     void render(wxPaintEvent& evt);
+    void renderFull(int renderIters = 1000, int renderWidth = 1920, int renderHeight = 1080, int renderQuality = 2);
+    void renderFullFragmented(int renderIters = 1000, int renderWidth = 1920, int renderHeight = 1080, int renderQuality = 2, int nbFrags = 1);
 
     double getZoomSensivity();
+    int getFPS();
+
     void setZoomSensivity(double zoomSensivityArg);
 
     // events

--- a/ExplorerWindow.h
+++ b/ExplorerWindow.h
@@ -4,6 +4,7 @@
 #include <wx/statline.h>
 #include <wx/filepicker.h>
 #include <wx/splitter.h>
+#include <wx/collpane.h>
 #include "ExplorerGL.h"
 
 typedef unsigned char uchar;
@@ -24,11 +25,12 @@ private:
 	void colormapChanged(wxFileDirPickerEvent& evt);
 	void kernelChanged(wxFileDirPickerEvent& evt);
 	void updateDisplays(wxCommandEvent& evt);
-	void onKeyPressed(wxKeyEvent &evt);
+	void onKeyPressed(wxKeyEvent& evt);
+	void saveImg(wxCommandEvent& evt);
+	void displayProgress(wxCommandEvent& evt);
+	void onRenderResized(wxCollapsiblePaneEvent& evt);
 
 public:
-	int mode;
-
 	// the main sizers (leftSizer and rightSizer are in the main sizer)
 	wxBoxSizer* mainSizer;
 	wxBoxSizer* leftSizer;
@@ -37,6 +39,8 @@ public:
 	// controls
 	wxStaticText* winWidthDisplay; // display the width of the window
 	wxStaticText* winHeightDisplay; // display the height of the window
+	wxStaticText* fpsDisplay;
+	wxStaticText* progressDisplay;
 	wxSpinCtrl* qualityInput;
 	wxSpinCtrl* itersInput;
 	wxSpinCtrlDouble* sensivityInput;
@@ -46,16 +50,14 @@ public:
 	wxSpinCtrlDouble* colorFrequencyInput;
 	wxFilePickerCtrl* colormapInput;
 	wxFilePickerCtrl* kernelInput;
-
-	// sizer for each control, these sizers are added to leftSizer (the left side is a control panel)
-	// each control needs a horizontal sizer because there is a control and a label on the same line
-	wxBoxSizer* sensivitySizer;
-	wxBoxSizer* xCoordSizer;
-	wxBoxSizer* yCoordSizer;
-	wxBoxSizer* zoomSizer;
-	wxBoxSizer* colorFrequencySizer;
-	wxBoxSizer* colormapSizer;
+	wxSpinCtrl* rdrWidthInput;
+	wxSpinCtrl* rdrHeightInput;
+	wxSpinCtrl* rdrItersInput;
+	wxSpinCtrl* rdrQualityInput;
+	wxSpinCtrl* rdrFragmentsInput;
+	wxButton* saveButton;
 	wxBoxSizer* kernelSizer;
+	wxCollapsiblePane* renderPanel;
 
 	ExplorerGL* explorer;
 	wxBoxSizer* explorerSizer;

--- a/ImageGenWindow.cpp
+++ b/ImageGenWindow.cpp
@@ -1,0 +1,33 @@
+#include "ImageGenWindow.h"
+
+#define PREVIEW_ID 10001
+
+ImageGenWindow::ImageGenWindow(wxWindow* parent) : wxWindow(parent, wxID_ANY)
+{
+	this->SetBackgroundColour(*wxWHITE);
+
+	mainSizer = new wxBoxSizer(wxHORIZONTAL);
+	this->SetSizer(mainSizer);
+
+	leftPanel = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(250, 0));
+	leftSizer = new wxBoxSizer(wxVERTICAL);
+
+	leftSizer->AddSpacer(10);
+	
+
+
+	leftPanel->SetSizer(leftSizer);
+	leftPanel->SetScrollRate(5, 5);
+	mainSizer->Add(leftPanel, 0, wxEXPAND);
+
+	rightSizer = new wxBoxSizer(wxVERTICAL);
+	int args[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 16, 0 };
+	preview = new PreviewGL(this, PREVIEW_ID, args);
+	rightSizer->Add(preview, 1, wxEXPAND);
+	mainSizer->Add(rightSizer, 1, wxEXPAND);
+}
+
+ImageGenWindow::~ImageGenWindow()
+{
+
+}

--- a/ImageGenWindow.h
+++ b/ImageGenWindow.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "wx/wx.h"
+#include "PreviewGL.h"
+
+class ImageGenWindow :
+    public wxWindow
+{
+public:
+	ImageGenWindow(wxWindow* parent = nullptr);
+	~ImageGenWindow();
+
+private:
+
+public:
+	wxBoxSizer* mainSizer;
+	wxBoxSizer* leftSizer;
+	wxBoxSizer* rightSizer;
+
+	PreviewGL* preview;
+	wxScrolledWindow* leftPanel;
+};
+

--- a/PreviewGL.h
+++ b/PreviewGL.h
@@ -12,6 +12,9 @@
 #include <string>
 #include <fstream>
 #include <streambuf>
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
 #define MAIN_SHADER "mandelbrotShader.frag"
 #define DEFAULT_COLORMAP "colormaps/IDL_Black-White_Linear.frag"
 #define DEFAULT_KERNEL "kernels/defaultKernel.frag"
@@ -20,7 +23,7 @@
 
 class PreviewGL : public wxGLCanvas
 {
-protected:
+public:
 	wxGLContext* m_context;
 
 	GLuint mandelbrotProgramID;

--- a/PreviewGL.h
+++ b/PreviewGL.h
@@ -23,7 +23,7 @@
 
 class PreviewGL : public wxGLCanvas
 {
-public:
+protected:
 	wxGLContext* m_context;
 
 	GLuint mandelbrotProgramID;

--- a/SMA.h
+++ b/SMA.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <stdint.h>
+
+// implement a class for rolling averages
+// from https://tttapa.github.io/Pages/Mathematics/Systems-and-Control-Theory/Digital-filters/Simple%20Moving%20Average/C++Implementation.html
+
+template <uint8_t N, class input_t = uint16_t, class sum_t = uint32_t>
+class SMA {
+public:
+    input_t operator()(input_t input) {
+        sum -= previousInputs[index];
+        sum += input;
+        previousInputs[index] = input;
+        if (++index == N)
+            index = 0;
+        return (sum + (N / 2)) / N;
+    }
+
+    static_assert(
+        sum_t(0) < sum_t(-1),  // Check that `sum_t` is an unsigned type
+        "Error: sum data type should be an unsigned integer, otherwise, "
+        "the rounding operation in the return statement is invalid.");
+
+private:
+    uint8_t index = 0;
+    input_t previousInputs[N] = {};
+    sum_t sum = 0;
+};

--- a/cMain.h
+++ b/cMain.h
@@ -2,7 +2,7 @@
 #include "wx/wx.h"
 #include <wx/spinctrl.h>
 #include <wx/statline.h>
-#include "explorerWindow.h"
+#include "ExplorerWindow.h"
 
 
 enum modes { exploreMandelbrot, generateVideo, generateImage, NB_MODES };


### PR DESCRIPTION
It is now possible to generate and save images from the explorer screen. The image is generated in "fragments", the program may crash if there are too few fragments but the more fragments the slower it will be.
I also added a few more kernels:
- "coloredNormalMapKernelFloats", which looks a tiny bit less good "coloredNormalMapKernel" (the difference is really barely noticeable) but is compatible with more systems.
- "juliaKernel" which generates a julia set instead of the Mandelbrot set (the julia set it generates is defined with a constant at the beginning of the shader)
- "derivativeKernel" which is like the default kernel except it colors each point according to magnitude of the derivative instead of the magnitude of z (it was originally created because of a mistake)
- "derivativeNormalMapKernel" which is like "derivativeKernel" but multiplied by the output of "normalMapKernel" to give a 3D effect